### PR TITLE
Only prune DONE tasks

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -617,7 +617,7 @@ class SimpleTaskState(object):
 
     def update_status(self, task, config):
         # Mark tasks with no remaining active stakeholders for deletion
-        if (not task.stakeholders) and (task.remove is None) and (task.status != RUNNING):
+        if (not task.stakeholders) and (task.remove is None) and (task.status == DONE):
             # We don't check for the RUNNING case, because that is already handled
             # by the fail_dead_worker_task function.
             logger.debug("Task %r has no stakeholders anymore -> might remove "


### PR DESCRIPTION
AIQ-specific commit. For our use case it's helpful to keep (for example) `DISABLED` tasks around for a longer period of time, but `DONE` tasks aren't as useful, so we can set the prune delay to a much lower number and only prune those.