### PR TITLE
ING-178 Separate configs from DONE vs DISABLED task removal

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -782,8 +782,12 @@ disable-window-seconds
 record_task_history
   If true, stores task history in a database. Defaults to false.
 
-remove_delay
-  Number of seconds to wait before removing a task that has no
+done_remove_delay
+  Number of seconds to wait before removing a DONE task that has no
+  stakeholders. Defaults to 600 (10 minutes).
+
+disabled_remove_delay
+  Number of seconds to wait before removing a DISABLED task that has no
   stakeholders. Defaults to 600 (10 minutes).
 
 retry_delay

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -1937,7 +1937,7 @@ class SchedulerApiTest(unittest.TestCase):
         """
         Test how assistants affect longevity of tasks
 
-        Assistants should not affect longevity expect for the tasks that it is
+        Assistants should not affect longevity except for the tasks that it is
         running, par the one it's actually running.
         """
         self.sch = Scheduler(retry_delay=100000000000)  # Never pendify failed tasks
@@ -1961,8 +1961,9 @@ class SchedulerApiTest(unittest.TestCase):
         self.setTime(200000)
         self.sch.ping(worker='assistant')
         self.sch.prune()
-        nurtured_statuses = [RUNNING]
-        not_nurtured_statuses = [DONE, UNKNOWN, DISABLED, PENDING, FAILED]
+        # we only prune DONE and DISABLED tasks, never any other status
+        nurtured_statuses = [PENDING, RUNNING, FAILED, UNKNOWN]
+        not_nurtured_statuses = [DONE, DISABLED]
 
         for status in nurtured_statuses:
             self.assertEqual(set([status.lower()]), set(self.sch.task_list(status, '')))
@@ -1970,7 +1971,7 @@ class SchedulerApiTest(unittest.TestCase):
         for status in not_nurtured_statuses:
             self.assertEqual(set([]), set(self.sch.task_list(status, '')))
 
-        self.assertEqual(1, len(self.sch.task_list(None, '')))  # None == All statuses
+        self.assertEqual(4, len(self.sch.task_list(None, '')))  # None == All statuses
 
     def test_no_crash_on_only_disable_hard_timeout(self):
         """

--- a/test/scheduler_api_test.py
+++ b/test/scheduler_api_test.py
@@ -882,9 +882,9 @@ class SchedulerApiTest(unittest.TestCase):
     def test_keep_failed_tasks_for_assistant(self):
         self.sch.get_work(worker='MAYBE_ASSISTANT', assistant=True)  # tell the scheduler this is an assistant
         self.sch.add_task(worker=WORKER, task_id='D', status=FAILED, deps=['A'])
-        # C is PENDING, D is FAILED, and A is a needed dep of D
+        # C is PENDING, D is FAILED
         # other tasks are gone
-        self._test_prune_tasks(wait=self.get_scheduler_config()['disabled_remove_delay']*2, expected=['A', 'C', 'D'])
+        self._test_prune_tasks(wait=self.get_scheduler_config()['disabled_remove_delay']*2, expected=['C', 'D'])
 
     def test_count_pending(self):
         for num_tasks in range(1, 20):

--- a/test/worker_test.py
+++ b/test/worker_test.py
@@ -123,7 +123,7 @@ class DummyErrorTask(Task):
 class WorkerTest(LuigiTestCase):
 
     def run(self, result=None):
-        self.sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10, stable_done_cooldown_secs=0)
+        self.sch = Scheduler(retry_delay=100, worker_disconnect_delay=10, stable_done_cooldown_secs=0)
         self.time = time.time
         with Worker(scheduler=self.sch, worker_id='X') as w, Worker(scheduler=self.sch, worker_id='Y') as w2:
             self.w = w
@@ -529,7 +529,7 @@ class WorkerTest(LuigiTestCase):
         eb = ExternalB()
         self.assertEqual(str(eb), "B()")
 
-        sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        sch = Scheduler(retry_delay=100, worker_disconnect_delay=10)
         with Worker(scheduler=sch, worker_id='X') as w, Worker(scheduler=sch, worker_id='Y') as w2:
             self.assertTrue(w.add(b))
             self.assertTrue(w2.add(eb))
@@ -554,7 +554,7 @@ class WorkerTest(LuigiTestCase):
 
         self.assertEqual(str(eb), "B()")
 
-        sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        sch = Scheduler(retry_delay=100, worker_disconnect_delay=10)
         with Worker(scheduler=sch, worker_id='X') as w, Worker(scheduler=sch, worker_id='Y') as w2:
             self.assertTrue(w2.add(eb))
             self.assertTrue(w.add(b))
@@ -585,7 +585,7 @@ class WorkerTest(LuigiTestCase):
 
         b = B()
 
-        sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        sch = Scheduler(retry_delay=100, worker_disconnect_delay=10)
 
         with Worker(scheduler=sch, worker_id='X', keep_alive=True, count_uniques=True) as w:
             with Worker(scheduler=sch, worker_id='Y', keep_alive=True, count_uniques=True, wait_interval=0.1, wait_jitter=0.05) as w2:
@@ -619,7 +619,7 @@ class WorkerTest(LuigiTestCase):
 
         b = B()
 
-        sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        sch = Scheduler(retry_delay=100, worker_disconnect_delay=10)
 
         with Worker(scheduler=sch, worker_id='X', keep_alive=True, count_uniques=True) as w:
             with Worker(scheduler=sch, worker_id='Y', keep_alive=True, count_uniques=True, wait_interval=0.1, wait_jitter=0.05) as w2:
@@ -652,7 +652,7 @@ class WorkerTest(LuigiTestCase):
                 return a, c
 
         b = B()
-        sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        sch = Scheduler(retry_delay=100, worker_disconnect_delay=10)
         with Worker(scheduler=sch, worker_id="foo") as w:
             self.assertFalse(w.add(b))
             self.assertTrue(w.run())
@@ -685,7 +685,7 @@ class WorkerTest(LuigiTestCase):
                 return c, a
 
         b = B()
-        sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        sch = Scheduler(retry_delay=100, worker_disconnect_delay=10)
         with Worker(scheduler=sch, worker_id="foo") as w:
             self.assertFalse(w.add(b))
             self.assertTrue(w.run())
@@ -939,7 +939,7 @@ class WorkerKeepAliveTests(LuigiTestCase):
 
 class WorkerInterruptedTest(unittest.TestCase):
     def setUp(self):
-        self.sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        self.sch = Scheduler(retry_delay=100, worker_disconnect_delay=10)
 
     requiring_sigusr = unittest.skipUnless(hasattr(signal, 'SIGUSR1'),
                                            'signal.SIGUSR1 not found on this system')
@@ -988,7 +988,7 @@ class WorkerInterruptedTest(unittest.TestCase):
 
 class WorkerDisabledTest(LuigiTestCase):
     def make_sch(self):
-        return Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        return Scheduler(retry_delay=100, worker_disconnect_delay=10)
 
     def _test_stop_getting_new_work_build(self, sch, worker):
         """
@@ -1088,7 +1088,6 @@ class WorkerPingThreadTests(unittest.TestCase):
         """
         sch = Scheduler(
             retry_delay=100,
-            remove_delay=1000,
             worker_disconnect_delay=10,
         )
 
@@ -1146,7 +1145,7 @@ class WorkerEmailTest(LuigiTestCase):
 
     def run(self, result=None):
         super(WorkerEmailTest, self).setUp()
-        sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        sch = Scheduler(retry_delay=100, worker_disconnect_delay=10)
         with Worker(scheduler=sch, worker_id="foo") as self.worker:
             super(WorkerEmailTest, self).run(result)
 
@@ -1626,7 +1625,7 @@ class Dummy2Task(Task):
 
 class AssistantTest(unittest.TestCase):
     def run(self, result=None):
-        self.sch = Scheduler(retry_delay=100, remove_delay=1000, worker_disconnect_delay=10)
+        self.sch = Scheduler(retry_delay=100, worker_disconnect_delay=10)
         self.assistant = Worker(scheduler=self.sch, worker_id='Y', assistant=True)
         with Worker(scheduler=self.sch, worker_id='X') as w:
             self.w = w


### PR DESCRIPTION
So, after this change:

- We will remove `DONE` tasks from the UI after `done_remove_delay`
- We will remove `DISABLED` tasks from the UI after `disabled_remove_delay`
- We will not remove any other tasks from the UI (at all)

Fixed up old unit tests and added new ones to make sure behavior conforms to this understanding