### PR TITLE
handle short lived stakeholders

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -752,7 +752,8 @@ class Scheduler(object):
             remove_workers = all_stakeholders.difference(useful_stakeholders)
             # Don't prune an active worker
             for active_worker in self._state.get_active_workers():
-                remove_workers.remove(active_worker.id)
+                if active_worker.id in remove_workers:
+                    remove_workers.remove(active_worker.id)
             self._state.remove_workers_from_tasks(remove_workers, True)
 
     @rpc_method()


### PR DESCRIPTION
This is solving a complicated situation.  In short, luigi uses the worker that creates the task (and therefore the task tree) as a "stakeholder" and will not remove any tasks from memory until that stakeholder worker dies.  In typical luigi world, you run a lugi task via a worker and that worker does all the jobs in the dependency tree.  So in theory, a task will never get removed from memory if it is part of a dependency tree while other tasks are running.  However, we have implemented it so the scheduler creates a short lived worker to queue up the task.  The stakeholder is gone within the timeout (180s), so any tasks in the dependency tree can easily get removed from memory.  This leads to the possibility of tasks being in an "unknown" state.
For example:
Task A depends on B and C, where B finishes in 5 minutes but C finishes in 6 hours.  We schedule A to run, it goes into pending, and B and C start.  B finishes, but C takes the 6 hours.  By the time C finishes, B will have been removed from memory.  A can never run (without manual intervention) because its dependency is an unknown state.

This update creates a config flag that says when a worker is not around anymore, don't remove it from stakeholders (but still remove it as a worker).  Also, when the flag is enabled, do a separate sweep of tasks to figure out which stakeholders are not attached to any useful task (task in pending or running or whatever), and then remove those stakeholders so tasks can get cleaned up properly