### PR TITLE
Ignore unknown status tasks when calculating short lived stakeholders

### DIFF
--- a/luigi/scheduler.py
+++ b/luigi/scheduler.py
@@ -747,7 +747,7 @@ class Scheduler(object):
             for task in self._state.get_active_tasks():
                 all_stakeholders.update(task.stakeholders)
                 # Tasks that are not done or disabled are useful
-                if task.status != DONE and task.status != DISABLED:
+                if task.status != DONE and task.status != DISABLED and task.status != UNKNOWN:
                     useful_stakeholders.update(task.stakeholders)
             remove_workers = all_stakeholders.difference(useful_stakeholders)
             # Don't prune an active worker


### PR DESCRIPTION
## Description
Right now we are taking unknown state tasks into account with
whether a stakeholder is active.  This is preventing some old
"DONE" tasks from getting cleaned up.